### PR TITLE
ci: delegate preflight checks to qrb_ros_gh_actions reusable workflow

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -1,24 +1,13 @@
 name: Qualcomm Preflight Checks
 on:
   pull_request:
-    branches: [ main ]
   push:
-    branches: [ main ]
   workflow_dispatch:
 
 permissions:
- contents: read
- security-events: write
+  contents: read
+  security-events: write
 
 jobs:
   qcom-preflight-checks:
-    uses: qualcomm/qcom-reusable-workflows/.github/workflows/qcom-preflight-checks-reusable-workflow.yml@v1.1.4
-    with:
-        # ✅ Preflight Checkers
-        repolinter: true                   # default: true
-        semgrep: true                      # default: true
-        copyright-license-detector: true   # default: true
-        pr-check-emails: true              # default: true
-        dependency-review: true            # default: true
-    secrets:
-      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+    uses: qualcomm-qrb-ros/qrb_ros_gh_actions/.github/workflows/qcom-preflight-checks.yml@main


### PR DESCRIPTION
Replace the direct call to Qualcomm upstream with a call to `qualcomm-qrb-ros/qrb_ros_gh_actions/.github/workflows/qcom-preflight-checks.yml@main`.

**Why:** Centralises version management — future upstream upgrades only need a single PR in `qrb_ros_gh_actions`, not one per repo.

**Depends on:** `qrb_ros_gh_actions` PR that adds `workflow_call` to that workflow.
